### PR TITLE
frontend.cancel.feature et al.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ OR follow these steps (Linux):
     cd fundraising-browsertests
     bundle install  
 
+You have to have [geckodriver installed](https://stackoverflow.com/questions/40669953/watir-unable-to-find-mozilla-geckodriver) 
+for the tests to be able to interact with your browser.
+
 ## Configuration
 
 PayPal Sandbox parameters in config.yml

--- a/features/step_definitions/frontend_comment_steps.rb
+++ b/features/step_definitions/frontend_comment_steps.rb
@@ -31,5 +31,5 @@ And(/^I click the submit comment button$/) do
 end
 
 Then(/^a positive feedback should show$/) do
-  expect(on(FrontendCommentPage).div_positiv_feedback_element.when_visible).to be_visible
+  expect(on(FrontendCommentPage).div_positiv_feedback_element.wait_until_present)
 end

--- a/features/step_definitions/frontend_contactform_steps.rb
+++ b/features/step_definitions/frontend_contactform_steps.rb
@@ -43,5 +43,5 @@ Then(/^The contact message confirmation page shows$/) do
 end
 
 Then(/^The field (.*) has an error message/) do |field|
-  expect(on(FrontendContactFormPage).error_for_field(field).when_visible).to be_visible
+  expect(on(FrontendContactFormPage).error_for_field(field).wait_until_present)
 end

--- a/features/step_definitions/frontend_credit_steps.rb
+++ b/features/step_definitions/frontend_credit_steps.rb
@@ -2,11 +2,8 @@
 # @author Christoph Fischer <christoph.fischer@wikimedia.de>
 
 Then(/^The credit card form shows$/) do
-  on(FrontendCreditPage) do |page|
-    page.wait_until do
-      page.input_holder_element.visible?
-    end
-  end
+  expect(on(FrontendCreditPage).micropayment_iframe_element.wait_until_present)
+  expect(on(FrontendCreditPage).input_holder_element.wait_until_present)
 end
 
 And(/^The cardholder should be the surname and name$/) do

--- a/features/step_definitions/frontend_debit_steps.rb
+++ b/features/step_definitions/frontend_debit_steps.rb
@@ -34,5 +34,5 @@ And(/^I confirm the notification contract$/) do
 end
 
 Then(/^The debit receipt shows$/) do
-  expect(on(FrontendReceiptPage).div_debit_confirmation_element.when_visible).to be_visible
+  expect(on(FrontendReceiptPage).div_debit_confirmation_element.wait_until_present)
 end

--- a/features/step_definitions/frontend_deposit_steps.rb
+++ b/features/step_definitions/frontend_deposit_steps.rb
@@ -6,5 +6,5 @@ And(/^The donation amount should show (.*) Euro$/) do |amount|
 end
 
 Then(/^The deposit donation confirmation shows$/) do
-  expect(on(FrontendReceiptPage).div_deposit_confirmation_element.when_visible).to be_visible
+  expect(on(FrontendReceiptPage).div_deposit_confirmation_element.wait_until_present)
 end

--- a/features/step_definitions/frontend_membership_steps.rb
+++ b/features/step_definitions/frontend_membership_steps.rb
@@ -48,7 +48,7 @@ And(/^I click on the continue member button$/) do
 end
 
 Then(/^The membership confirmation shows$/) do
-  expect(on(FrontendReceiptPage).div_membership_confirmation_element.when_visible).to be_visible
+  expect(on(FrontendReceiptPage).div_membership_confirmation_element.wait_until_present)
 end
 
 And(/^I enter (\d+) euro in the amount field$/) do |arg|

--- a/features/step_definitions/frontend_paypal_steps.rb
+++ b/features/step_definitions/frontend_paypal_steps.rb
@@ -2,11 +2,7 @@
 # @author Christoph Fischer <christoph.fischer@wikimedia.de>
 
 Then(/^The paypal form shows$/) do
-  on(FrontendPaypalPage) do |page|
-    page.wait_until do
-      page.div_xpt_content_main_element.visible?
-    end
-  end
+  expect(on(FrontendPaypalPage).div_xpt_content_main_element.wait_until_present)
 end
 
 And(/^The paypal should be the surname and name$/) do
@@ -19,6 +15,7 @@ And(/^The paypal donation amount should show (.*) Euro$/) do |amount|
 end
 
 And(/^I login with my paypal credentials$/) do
+  step('The paypal form shows')
   on(FrontendPaypalPage).input_login_email_element.when_visible.value = ENV['PAYPAL_USERNAME']
   on(FrontendPaypalPage).input_login_password_element.value = ENV['PAYPAL_PASSWORD']
   on(FrontendPaypalPage).button_login_element.click
@@ -26,7 +23,7 @@ end
 
 And(/^I click on the paypal continue button$/) do
   # This page takes a long time to load and the test may fail.
-  on(FrontendPaypalPage).button_continue_element.when_visible.click
+  on(FrontendPaypalPage).button_continue_element.wait_until_present.click
 end
 
 Then(/^The normal donation confirmation shows$/) do

--- a/features/support/pages/frontend_creditpage.rb
+++ b/features/support/pages/frontend_creditpage.rb
@@ -4,6 +4,8 @@
 class FrontendCreditPage
   include PageObject
 
+  element(:micropayment_iframe, id: 'micropayment-portal')
+
   in_iframe({ id: 'micropayment-portal' }) do |mcp_frame|
     text_field(:input_holder, id: 'holder', frame: mcp_frame)
     text_field(:input_card_number, id: 'card-number', frame: mcp_frame)


### PR DESCRIPTION
Addressing tests that all struggled waiting for elements on page change.

Check out if it works better for you.

Tests that remain broken for me even with these changes applied:

* unclear (I don't have paypal, yet)
  * cucumber features/frontend.paypal.feature:32 # Scenario: Check the non anonymous paypal donation

* broken in app?
  * cucumber features/frontend.contactform.feature:14 # Scenario: Checks if relevant error message is shown when insufficient data is entered
  * cucumber features/frontend.contactform.feature:14 # Scenario: Checks if relevant error message is shown when insufficient data is entered
  * cucumber features/frontend.contactform.feature:14 # Scenario: Checks if relevant error message is shown when insufficient data is entered

* "broken by design" 
  * cucumber features/wpde.address.feature:15 # Scenario: Checks if insufficient address data stops the process
  * cucumber features/wpde.credit.feature:15 # Scenario: Check the anonymous credit card donation
  * cucumber features/wpde.debit.feature:12 # Scenario: Checks if debit donation transfers the transfers the right amount  
  * cucumber features/wpde.deposit.feature:11 # Scenario: Checks if deposit donation transfers the right amount
  * cucumber features/wpde.frontpage.feature:13 # Scenario: Checks if the lightbox shows when continuing
  * cucumber features/wpde.paypal.feature:12 # Scenario: Checks if the chosen value is displayed correctly
