### PR TITLE
T163905 flagging tests depending on banner campaign, exclude them by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,14 +34,20 @@ Frontend URL
 
 ## Executing tests
 
-Update/install gems
-```shell
-bundle update
-```
+Tests are organized in *feature*s that have a *background* and one or more *scenario*s.
+Each feature and/or scenario can be [tagged](https://github.com/cucumber/cucumber/wiki/Tags) to
+organise the tests.
 
-Run all tests
+Run all tests (as per the [*default* profile](config/cucumber.yml))
 ```shell
 bundle exec cucumber
+```
+
+### More complex invocation options
+
+Run all (really all) tests
+```shell
+bundle exec cucumber -P
 ```
 
 Run a specific feature

--- a/config/cucumber.yml
+++ b/config/cucumber.yml
@@ -1,0 +1,2 @@
+# do not run tests that depend on 3rd party configuration (active banner campaign) by default
+default: --tags ~@banner_campaign

--- a/features/wpde.address.feature
+++ b/features/wpde.address.feature
@@ -2,6 +2,7 @@
 # @author Christoph Fischer <christoph.fischer@wikimedia.de>
 
 @ui_only
+@banner_campaign
 Feature: Check the address validation on the wikipedia.de banner lightbox
 
   Background:

--- a/features/wpde.credit.feature
+++ b/features/wpde.credit.feature
@@ -1,6 +1,7 @@
 # @licence GNU GPL v2+
 # @author Christoph Fischer <christoph.fischer@wikimedia.de>
 
+@banner_campaign
 Feature: Check the credit process on the wikipedia.de banner lightbox
 
   Background:

--- a/features/wpde.debit.feature
+++ b/features/wpde.debit.feature
@@ -1,13 +1,13 @@
 # @licence GNU GPL v2+
 # @author Christoph Fischer <christoph.fischer@wikimedia.de>
 
+@banner_campaign
 Feature: Check the debit process on the wikipedia.de banner lightbox
 
   Background:
     Given I am on the wikipedia.de frontpage
     And The wikipedia.de lightbox banner shows
     And I change the lightbox to testmode
-
 
   Scenario Outline: Checks if debit donation transfers the transfers the right amount
     When I click the banner <option> amount option

--- a/features/wpde.deposit.feature
+++ b/features/wpde.deposit.feature
@@ -1,6 +1,7 @@
 # @licence GNU GPL v2+
 # @author Christoph Fischer <christoph.fischer@wikimedia.de>
 
+@banner_campaign
 Feature: Check the deposit process on the wikipedia.de banner lightbox
 
   Background:

--- a/features/wpde.frontpage.feature
+++ b/features/wpde.frontpage.feature
@@ -2,6 +2,7 @@
 # @author Christoph Fischer <christoph.fischer@wikimedia.de>
 
 @ui_only
+@banner_campaign
 Feature: Checks the ui on the wikipedia.de banner lightbox
 
   Background:

--- a/features/wpde.paypal.feature
+++ b/features/wpde.paypal.feature
@@ -1,6 +1,7 @@
 # @licence GNU GPL v2+
 # @author Christoph Fischer <christoph.fischer@wikimedia.de>
 
+@banner_campaign
 Feature: Check the paypal process on the wikipedia.de banner lightbox
 
   Background:


### PR DESCRIPTION
* do not run tests that depend on 3rd party configuration (active banner campaign) by default